### PR TITLE
Add OPL3 voice and event tracking infrastructure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "files.associations": {
-        "math.h": "c"
+        "math.h": "c",
+        "opl3_convert.h": "c",
+        "opl3_voice.h": "c"
     }
 }

--- a/src/opl3_convert.h
+++ b/src/opl3_convert.h
@@ -5,11 +5,12 @@
 #include <stdbool.h>
 #include "vgm_helpers.h"
 
+#define OPL3_NUM_CHANNELS 18
 // --- Channel registers state ---
 typedef struct {
-    uint8_t regA[9];
-    uint8_t regB[9];
-    uint8_t regC[9];
+    uint8_t regA[OPL3_NUM_CHANNELS];
+    uint8_t regB[OPL3_NUM_CHANNELS];
+    uint8_t regC[OPL3_NUM_CHANNELS];
     bool rhythm_mode;
     bool opl3_mode_initialized;
 } OPL3State;

--- a/src/opl3_event.c
+++ b/src/opl3_event.c
@@ -1,0 +1,27 @@
+#include "opl3_convert.h"
+#include "opl3_event.h"
+#include <stdlib.h>
+#include <string.h>
+
+// Initialize event list
+void opl3_event_list_init(OPL3EventList *list) {
+    list->count = 0;
+    list->capacity = 64;
+    list->events = (OPL3Event*)calloc(list->capacity, sizeof(OPL3Event));
+}
+
+// Free event list
+void opl3_event_list_free(OPL3EventList *list) {
+    if (list->events) free(list->events);
+    list->events = NULL;
+    list->count = list->capacity = 0;
+}
+
+// Add event to the list (auto-expand)
+void opl3_event_list_add(OPL3EventList *list, const OPL3Event *event) {
+    if (list->count >= list->capacity) {
+        list->capacity *= 2;
+        list->events = (OPL3Event*)realloc(list->events, list->capacity * sizeof(OPL3Event));
+    }
+    list->events[list->count++] = *event;
+}

--- a/src/opl3_event.h
+++ b/src/opl3_event.h
@@ -1,0 +1,48 @@
+#ifndef OPL3_EVENT_H
+#define OPL3_EVENT_H
+
+#include <stdint.h>
+
+// OPL3 event type enumeration
+typedef enum {
+    OPL3_EVENT_NONE = 0,
+    OPL3_EVENT_KEYON,
+    OPL3_EVENT_KEYOFF,
+    OPL3_EVENT_NOTE,      // Generic note event (optional, for MML etc.)
+    OPL3_EVENT_PITCH,     // F-Number, Block, etc.
+    OPL3_EVENT_VOICECHANGE,
+    OPL3_EVENT_CONTROL,   // Expression, pitch bend, modulation, etc.
+    OPL3_EVENT_WAIT,      // Wait/delta time
+    OPL3_EVENT_SYSTEM,    // System/meta event (for tempo, etc.)
+} OPL3EventType;
+
+// OPL3 event structure
+typedef struct {
+    OPL3EventType type;      // Event type
+    uint32_t timestamp;      // Absolute sample count or tick
+    uint8_t channel;         // Logical OPL3 channel (0..17)
+    uint8_t note;            // MIDI note number (0..127), if applicable
+    uint8_t velocity;        // Velocity (0..127), if applicable (KeyOn/KeyOff)
+    int voice_id;            // Voice ID (refer to OPL3VoiceDB), -1 if N/A
+    uint16_t fnum;           // FM F-Number (pitch), for pitch events
+    uint8_t block;           // FM Block (octave), for pitch events
+    uint8_t control_type;    // Control type (expression, modulation, etc.), OPL3/MIDI
+    int16_t control_value;   // Control value (signed), for control events
+    uint32_t wait_value;     // Number of samples/ticks to wait (for WAIT type)
+    uint32_t meta_value;     // System/meta (e.g., tempo, time signature)
+    // You can add more fields as needed for advanced export (e.g. detune, pan, etc.)
+} OPL3Event;
+
+// Dynamic event list for easy appending (expandable array)
+typedef struct {
+    OPL3Event *events;
+    int count;
+    int capacity;
+} OPL3EventList;
+
+// Utility functions
+void opl3_event_list_init(OPL3EventList *list);
+void opl3_event_list_free(OPL3EventList *list);
+void opl3_event_list_add(OPL3EventList *list, const OPL3Event *event);
+
+#endif // OPL3_EVENT_H

--- a/src/opl3_voice.c
+++ b/src/opl3_voice.c
@@ -1,0 +1,93 @@
+#include "opl3_convert.h"
+#include "opl3_voice.h"
+#include <string.h>
+#include <stdlib.h>
+
+// Initialize the voice database
+void opl3_voice_db_init(OPL3VoiceDB *db) {
+    db->count = 0;
+    db->capacity = 16;
+    db->voices = (OPL3VoiceParam*)calloc(db->capacity, sizeof(OPL3VoiceParam));
+}
+
+// Free the voice database
+void opl3_voice_db_free(OPL3VoiceDB *db) {
+    if (db->voices) free(db->voices);
+    db->voices = NULL;
+    db->count = db->capacity = 0;
+}
+
+// Compare two OPL3VoiceParam
+static int opl3_voice_param_cmp(const OPL3VoiceParam *a, const OPL3VoiceParam *b) {
+    return memcmp(a, b, sizeof(OPL3VoiceParam));
+}
+
+// Find or add a new voice, return its Voice ID (0-based)
+int opl3_voice_db_find_or_add(OPL3VoiceDB *db, const OPL3VoiceParam *vp) {
+    for (int i = 0; i < db->count; ++i) {
+        if (opl3_voice_param_cmp(&db->voices[i], vp) == 0) {
+            return i;
+        }
+    }
+    // Add new voice
+    if (db->count >= db->capacity) {
+        db->capacity *= 2;
+        db->voices = (OPL3VoiceParam*)realloc(db->voices, db->capacity * sizeof(OPL3VoiceParam));
+    }
+    db->voices[db->count] = *vp;
+    return db->count++;
+}
+
+// Check if given channel is in 4op mode (reg_104: OPL3 0x104)
+int is_4op_channel(const uint8_t reg_104, int ch) {
+    // OPL3 4op pairs: 0+3 (bit0), 1+4 (bit1), 2+5 (bit2)
+    if (ch == 0 || ch == 3) return (reg_104 & 0x01) ? 2 : 1;
+    if (ch == 1 || ch == 4) return (reg_104 & 0x02) ? 2 : 1;
+    if (ch == 2 || ch == 5) return (reg_104 & 0x04) ? 2 : 1;
+    // OPL3 4op is only for ch0-5
+    return 1;
+}
+
+// Extract voice parameters for the specified channel
+// state: pointer to OPL3State (must contain regA, regB, regC)
+// ch: logical channel (0..17), reg_104: OPL3 0x104 value
+void extract_voice_param(const OPL3State *state, int ch, uint8_t reg_104, OPL3VoiceParam *out) {
+    memset(out, 0, sizeof(OPL3VoiceParam));
+    int mode = is_4op_channel(reg_104, ch);
+    out->is_4op = mode;
+    int ch_main = ch;
+    int ch_pair = -1;
+    if (mode == 2) {
+        // Determine 4op channel pair
+        if (ch < 3) ch_pair = ch + 3;
+        else if (ch >= 3 && ch <= 5) ch_pair = ch - 3;
+        // For 4op: collect both channels
+    }
+    int chs[2] = {ch_main, (mode == 2 ? ch_pair : -1)};
+    for (int pair = 0; pair < (mode == 2 ? 2 : 1); ++pair) {
+        int c = chs[pair];
+        if (c < 0) continue;
+        // OPL3 operator mapping (see OPL3 docs)
+        for (int op = 0; op < 2; ++op) {
+            // Operator index for OPL3: slot = ch + op*3
+            int op_idx = c + op * 3;
+            OPL3OperatorParam *opp = &out->op[pair * 2 + op];
+            // The following assumes state contains regA, regB, regC arrays for 18 channels (port0+port1)
+            opp->am   = (state->regA[op_idx] >> 7) & 1;
+            opp->vib  = (state->regA[op_idx] >> 6) & 1;
+            opp->egt  = (state->regA[op_idx] >> 5) & 1;
+            opp->ksr  = (state->regA[op_idx] >> 4) & 1;
+            opp->mult =  state->regA[op_idx] & 0x0F;
+            opp->ksl  = (state->regB[op_idx] >> 6) & 3;
+            // TL intentionally omitted
+            opp->ar   = (state->regB[op_idx] >> 0) & 0x1F;
+            opp->dr   = (state->regC[op_idx] >> 4) & 0x0F;
+            opp->sl   = (state->regC[op_idx] >> 0) & 0x0F;
+            opp->rr   = (state->regB[op_idx] >> 0) & 0x0F;
+            opp->ws   = (state->regC[op_idx] >> 0) & 0x07;
+        }
+        // Feedback and connection type
+        out->fb[pair]  = (state->regC[c] >> 1) & 0x07;
+        out->cnt[pair] = (state->regC[c] >> 0) & 0x01;
+    }
+}

--- a/src/opl3_voice.h
+++ b/src/opl3_voice.h
@@ -1,0 +1,35 @@
+#ifndef OPL3_VOICE_H
+#define OPL3_VOICE_H
+
+#include <stdint.h>
+#include "opl3_convert.h"
+
+// OPL3 operator parameter set (TL excluded)
+typedef struct {
+    uint8_t am, vib, egt, ksr, mult;
+    uint8_t ksl, ar, dr, sl, rr, ws;
+} OPL3OperatorParam;
+
+// 2op/4op compatible voice structure
+typedef struct {
+    int is_4op; // 1: 2op, 2: 4op
+    OPL3OperatorParam op[4]; // [0..1]: 2op, [0..3]: 4op
+    uint8_t fb[2];   // Feedback for each 2op pair
+    uint8_t cnt[2];  // Connection type for each 2op pair
+} OPL3VoiceParam;
+
+// Dynamic array for voice database
+typedef struct {
+    OPL3VoiceParam *voices;
+    int count;
+    int capacity;
+} OPL3VoiceDB;
+
+// Utility
+void opl3_voice_db_init(OPL3VoiceDB *db);
+void opl3_voice_db_free(OPL3VoiceDB *db);
+int opl3_voice_db_find_or_add(OPL3VoiceDB *db, const OPL3VoiceParam *vp);
+int is_4op_channel(const uint8_t reg_104, int ch);
+void extract_voice_param(const OPL3State *state, int ch, uint8_t reg_104, OPL3VoiceParam *out);
+
+#endif // OPL3_VOICE_H


### PR DESCRIPTION
Introduces OPL3 voice parameter extraction and a dynamic voice database (opl3_voice.c/h), as well as an event system for logging OPL3 events (opl3_event.c/h). Updates opl3_convert.c/h to use these new systems, including global voice DB management and event logging on KeyOn. Also expands channel register arrays to support all 18 OPL3 channels and updates VSCode settings for new headers.